### PR TITLE
Fix BibTeX title in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The results will be saved in the `runs/` directory, which will be created automa
 If you find Prover Agent useful in your research, please consider citing the following paper:
 
 ```bibtex
-@article{baba2024proveragent,
+@article{baba2025proveragent,
   title={{Prover Agent}: An Agent-Based Framework for Formal Mathematical Proofs},
   author={Baba, Kaito and Liu, Chaoran and Kurita, Shuhei and Sannai, Akiyoshi},
   journal={arXiv preprint arXiv:2506.19923},


### PR DESCRIPTION
## 🎯 Motivation
The year in the BibTeX title is incorrect. This does not affect the citation year shown in the reference section, since the year field in the BibTeX entry is correct. However, it can be a bit confusing.

## 📝 Description of Changes


## 🔖 Additional Notes
